### PR TITLE
Wrapped brownian motion

### DIFF
--- a/examples/wrapped_brownian.jl
+++ b/examples/wrapped_brownian.jl
@@ -34,10 +34,8 @@ end
 
 expectation(x_t, t; P = P, target = (mus, sigs, weights)) = [expec(x, t, P, target) for x in x_t]
 
-rewrap(x, lb, ub) = mod(x - lb, ub - lb) + lb
-
 function wrapped_normal_pdf(mu, sig, x)
-    mu = rewrap(mu, -pi, pi)
+    mu = mod2pi(mu + pi) - pi
     d = Normal(mu, sig)
     return sum(pdf.(d, (-20*2pi+x):2pi:(20*2pi+x)))
 end

--- a/examples/wrapped_brownian.jl
+++ b/examples/wrapped_brownian.jl
@@ -1,8 +1,7 @@
 using Plots, Distributions, Diffusions
 
-function circular_mean(angles, weights = ones(length(angles)))
-    return atan(sum(sin.(angles) .* weights), sum(cos.(angles) .* weights))
-end
+circular_mean(angles, weights = ones(size(angles))) =
+    atan(sum(sin.(angles) .* weights), sum(cos.(angles) .* weights))
 
 function wrapped_combine(mu, var, back_mu, back_var)
     t_mu = [back_mu + k*2*pi for k in -10:1:10]
@@ -14,51 +13,43 @@ function wrapped_combine(mu, var, back_mu, back_var)
             (mu^2 ./ var) .+
             (t_mu.^2 ./ back_var) .- (new_means.^2 ./ new_var)
         )
-    return new_means , log_norm_consts
+    return new_means, log_norm_consts
 end
 
 function expec(x_t, t, P, target)
-    backvar = P.rate*t
-    mus,sigs,weights = target
+    backvar = P.rate * t
+    mus, sigs, weights = target
     ms = Float64[]
     lncs = Float64[]
-    for i in 1:length(weights)
-        m,l = wrapped_combine(mus[i], sigs[i]^2, x_t, backvar)
-        l .= l .+ log(weights[i])
-        ms = vcat(ms,m)
-        lncs = vcat(lncs,l)
+    for i in eachindex(mus, sigs, weights)
+        m, l = wrapped_combine(mus[i], sigs[i]^2, x_t, backvar)
+        l .+= log(weights[i])
+        append!(ms, m)
+        append!(lncs, l)
     end
     ncs = exp.(lncs .- maximum(lncs))
-    ncs .= ncs ./ sum(ncs)
+    ncs ./= sum(ncs)
     return circular_mean(ms, ncs)
 end
 
-function expectation(x_t, t; P = P, target = (mus,sigs,weights))
-    x_0 = similar(x_t)
-    for i in CartesianIndices(x_t)
-        x_0[i] = expec(x_t[i], t, P, target)
-    end
-    return x_0
+expectation(x_t, t; P = P, target = (mus, sigs, weights)) = [expec(x, t, P, target) for x in x_t]
+
+rewrap(x, lb, ub) = mod(x - lb, ub - lb) + lb
+
+function wrapped_normal_pdf(mu, sig, x)
+    mu = rewrap(mu, -pi, pi)
+    d = Normal(mu, sig)
+    return sum(pdf.(d, (-20*2pi+x):2pi:(20*2pi+x)))
 end
 
-function rewrap(x,lb,ub)
-    mod(x-lb,ub-lb)+lb
-end
+weights = [1/8, 1/8, 1/4, 1/2]
+mus, sigs = [pi-pi/10, pi, pi/2, 0], [0.5, 0.2, 0.05, 1.0]
+ps = sum([weights[i] .* wrapped_normal_pdf.(mus[i], sigs[i], -pi:pi/240:pi) for i in 1:4])
 
-function wrapped_normal_pdf(mu,sig,x)
-    mu = rewrap(mu,-pi,pi)
-    d = Normal(mu,sig)
-    sum(pdf.(d,(-20*2pi+x):2pi:(20*2pi+x)))
-end
+P = WrappedBrownianMotion(1.0)
+x_T = rand(Uniform(-pi, pi), 20000)
+timesteps = reverse([20 * 0.95^i for i in 0:400])
+@time samp = samplebackward(expectation, P, timesteps, x_T)
 
-weights = [1/8,1/8,1/4,1/2]
-mus, sigs = [pi-pi/10,pi, pi/2, 0], [0.5,0.2, 0.05, 1.0]
-ps = sum([weights[i] .* wrapped_normal_pdf.(mus[i],sigs[i],-pi:pi/240:pi) for i in 1:4])
-
-P = WrappedBrownianMotion{Float64}(1.0)
-x_T = rand(Uniform(-pi,pi),20000);
-timesteps = reverse([20 * 0.95^i for i in 0:400]);
-@time samp = samplebackward(expectation, P, timesteps, x_T);
-
-plot(-pi:pi/240:pi,ps)
-histogram!(samp, bins = -pi:pi/60:pi, normalize=:pdf, label = "Draws", linewidth = 0.0, xlim = (-pi,pi), alpha = 0.5)
+plot(-pi:pi/240:pi, ps)
+histogram!(samp, bins = -pi:pi/60:pi, normalize=:pdf, label = "Draws", linewidth = 0.0, xlim = (-pi, pi), alpha = 0.5)

--- a/src/Diffusions.jl
+++ b/src/Diffusions.jl
@@ -50,6 +50,7 @@ module Diffusions
         OrnsteinUhlenbeck,
         MultiGaussianState,
         WrappedBrownianMotion,
+        WrappedInterpolatedBrownianMotion,
         #Discrete
         IJ,
         DiscreteState,

--- a/src/Diffusions.jl
+++ b/src/Diffusions.jl
@@ -18,6 +18,7 @@ module Diffusions
     include("randomvariable.jl")
     include("continuous.jl")
     include("discrete.jl")
+    include("angles.jl")
     include("tractables.jl")
     include("denoiser.jl")
     include("tracker.jl")
@@ -48,6 +49,7 @@ module Diffusions
         #Continuous
         OrnsteinUhlenbeck,
         MultiGaussianState,
+        WrappedBrownianMotion,
         #Discrete
         IJ,
         DiscreteState,
@@ -62,7 +64,9 @@ module Diffusions
         eq_dist,
         values,
         var,
+        reangle,
         sampleforward,
-        samplebackward
+        samplebackward,
+        endpoint_conditioned_sample
 
 end

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -2,38 +2,32 @@ struct WrappedBrownianMotion{T <: Real} <: Process
     rate::T
 end
 
-eq_dist(model::WrappedBrownianMotion) = Uniform(-pi,pi)
+eq_dist(::WrappedBrownianMotion) = Uniform(-pi, pi)
 
-function rewrap(x,lb,ub)
-    mod(x-lb,ub-lb)+lb
-end
+rewrap(x, lb, ub) = mod(x - lb, ub - lb) + lb
+reangle(x) = rewrap(x, oftype(x, -pi), oftype(x, pi))
 
-reangle(x) = rewrap(x,-pi,pi)
-
-#See https://github.com/MurrellGroup/Diffusions.jl/issues/11
-    #This could be optimized to truncate based on the forward mu and var
-    #but this is probably fast enough and broad enough for the diffusion scales we'll consider
-function wrapped_combine_and_sample(rng, mu, var, back_mu, back_var)
-    t_mu = [back_mu + k*2*pi for k in -6:1:6]
-    new_var = 1 ./ (1 ./ var .+ 1 ./ back_var)
-    new_means = new_var .* (mu ./ var .+ t_mu ./ back_var)
+# See https://github.com/MurrellGroup/Diffusions.jl/issues/11
+# This could be optimized to truncate based on the forward mu and var
+# but this is probably fast enough and broad enough for the diffusion scales we'll consider
+function wrapped_combine_and_sample(
+    rng::AbstractRNG, mu::T, var::T, back_mu::T, back_var::T) where T <: Real
+    τ = T(2π)
+    t_mu = [back_mu + k * τ for k in -6:6]
+    new_var = 1 / (1 / var + 1 / back_var)
+    new_means = @. new_var * (mu / var + t_mu / back_var)
     log_norm_consts =
-        -0.5 .* (
-            log.(2 .* pi .* (var .* back_var ./ new_var)) .+
-            (mu^2 ./ var) .+
-            (t_mu.^2 ./ back_var) .- (new_means.^2 ./ new_var)
-        )
+        @. (
+            log(τ * (var * back_var / new_var)) +
+            (mu^2 / var) +
+            (t_mu^2 / back_var) - (new_means^2 / new_var)
+        ) / -2
     nw = exp.(log_norm_consts .- maximum(log_norm_consts))
-    component = rand(Categorical(nw ./ sum(nw)))
-    return reangle(new_means[component] + randn(rng)*sqrt(new_var))
+    component = rand(rng, Categorical(nw ./ sum(nw)))
+    return reangle(new_means[component] + randn(rng) * sqrt(new_var))
 end
 
 sampleforward(rng::AbstractRNG, P::WrappedBrownianMotion{T}, t::Real, X) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
 
-function endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedBrownianMotion{T}, s::Real, t::Real, x_0, x_t) where T <: Real
-    x_s = similar(x_0)
-    for i in eachindex(x_0)
-        x_s[i] = wrapped_combine_and_sample(rng, x_0[i], P.rate*s, x_t[i], P.rate*(t-s))
-    end
-    return x_s
-end
+endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedBrownianMotion, s::Real, t::Real, x_0, x_t) =
+    wrapped_combine_and_sample.(rng, x_0, P.rate * s, x_t, P.rate * (t - s))

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -4,8 +4,7 @@ end
 
 eq_dist(::WrappedBrownianMotion) = Uniform(-pi, pi)
 
-rewrap(x, lb, ub) = mod(x - lb, ub - lb) + lb
-reangle(x) = rewrap(x, oftype(x, -pi), oftype(x, pi))
+reangle(x) = mod2pi(x + pi) - pi
 
 # See https://github.com/MurrellGroup/Diffusions.jl/issues/11
 # This could be optimized to truncate based on the forward mu and var

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -1,5 +1,3 @@
-Base.broadcastable(x::Process) = Ref(x)
-
 abstract type WrappedDiffusion{T <: Real} <: SimulationProcess end
 
 struct WrappedBrownianMotion{T <: Real} <: WrappedDiffusion{T}

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -1,16 +1,21 @@
-struct WrappedBrownianMotion{T <: Real} <: Process
+Base.broadcastable(x::Process) = Ref(x)
+
+abstract type WrappedDiffusion{T <: Real} <: SimulationProcess end
+
+struct WrappedBrownianMotion{T <: Real} <: WrappedDiffusion{T}
     rate::T
 end
 
-eq_dist(::WrappedBrownianMotion) = Uniform(-pi, pi)
+struct WrappedInterpolatedBrownianMotion{T <: Real} <: WrappedDiffusion{T}
+    rate::T
+end
+
+eq_dist(::WrappedDiffusion) = Uniform(-pi, pi)
 
 reangle(x) = mod2pi(x + pi) - pi
 
-# See https://github.com/MurrellGroup/Diffusions.jl/issues/11
-# This could be optimized to truncate based on the forward mu and var
-# but this is probably fast enough and broad enough for the diffusion scales we'll consider
-function wrapped_combine_and_sample(
-    rng::AbstractRNG, mu::T, var::T, back_mu::T, back_var::T) where T <: Real
+function wrapped_combine_and_sample(rng::AbstractRNG, P::WrappedBrownianMotion, mu::T, var::T, back_mu::T, back_var::T) where T
+    #Exact bridge, using the mixture trick
     τ = T(2π)
     t_mu = [back_mu + k * τ for k in -6:6]
     new_var = 1 / (1 / var + 1 / back_var)
@@ -26,7 +31,33 @@ function wrapped_combine_and_sample(
     return reangle(new_means[component] + randn(rng) * sqrt(new_var))
 end
 
-sampleforward(rng::AbstractRNG, P::WrappedBrownianMotion{T}, t::Real, X) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
+function wrapped_combine_and_sample(rng::AbstractRNG, P::WrappedInterpolatedBrownianMotion, mu::T, var::T, back_mu::T, back_var::T) where T
+    #Approx bridge, using interpolation trick
+    B = sampleforward(rng, P, var, mu)
+    C = sampleforward(rng, P, back_var, B)
+    C = reangle(C)
+    back_mu = reangle(back_mu)
+    if back_mu > C
+        if back_mu - C < pi
+            shortestdist = back_mu - C
+            dir = 1
+        else
+            shortestdist = 2pi - (back_mu - C)
+            dir = -1
+        end
+    else
+        if C - back_mu < pi
+            shortestdist = C - back_mu
+            dir = -1
+        else
+            shortestdist = 2pi - (C - back_mu)
+            dir = 1
+        end
+    end
+    return reangle(B + dir * shortestdist * (var / (var + back_var)))
+end
 
-endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedBrownianMotion, s::Real, t::Real, x_0, x_t) =
-    wrapped_combine_and_sample.(rng, x_0, P.rate * s, x_t, P.rate * (t - s))
+sampleforward(rng::AbstractRNG, P::WrappedDiffusion{T}, t::Real, X) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
+
+endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedDiffusion, s::Real, t::Real, x_0, x_t) where T =
+    wrapped_combine_and_sample.(rng, P, x_0, P.rate * s, x_t, P.rate * (t - s))

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -1,0 +1,39 @@
+struct WrappedBrownianMotion{T <: Real} <: Process
+    rate::T
+end
+
+eq_dist(model::WrappedBrownianMotion) = Uniform(-pi,pi)
+
+function rewrap(x,lb,ub)
+    mod(x-lb,ub-lb)+lb
+end
+
+reangle(x) = rewrap(x,-pi,pi)
+
+#See https://github.com/MurrellGroup/Diffusions.jl/issues/11
+    #This could be optimized to truncate based on the forward mu and var
+    #but this is probably fast enough and broad enough for the diffusion scales we'll consider
+function wrapped_combine_and_sample(rng, mu, var, back_mu, back_var)
+    t_mu = [back_mu + k*2*pi for k in -6:1:6]
+    new_var = 1 ./ (1 ./ var .+ 1 ./ back_var)
+    new_means = new_var .* (mu ./ var .+ t_mu ./ back_var)
+    log_norm_consts =
+        -0.5 .* (
+            log.(2 .* pi .* (var .* back_var ./ new_var)) .+
+            (mu^2 ./ var) .+
+            (t_mu.^2 ./ back_var) .- (new_means.^2 ./ new_var)
+        )
+    nw = exp.(log_norm_consts .- maximum(log_norm_consts))
+    component = rand(Categorical(nw ./ sum(nw)))
+    return reangle(new_means[component] + randn(rng)*sqrt(new_var))
+end
+
+sampleforward(rng::AbstractRNG, P::WrappedBrownianMotion{T}, t::Real, X) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
+
+function endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedBrownianMotion{T}, s::Real, t::Real, x_0, x_t) where T <: Real
+    x_s = similar(x_0)
+    for i in eachindex(x_0)
+        x_s[i] = wrapped_combine_and_sample(rng, x_0[i], P.rate*s, x_t[i], P.rate*(t-s))
+    end
+    return x_s
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -13,6 +13,7 @@ sampleforward(process, t, x) = sampleforward(Random.default_rng(), process, t, x
 sampleforward(rng::AbstractRNG, process, t::Real, x) = sampleforward.(rng, process, t, x)
 sampleforward(rng::AbstractRNG, process::Process, t::Real, x) = sample(rng, forward(process, x, 0, t))
 
+
 """
     samplebackward(guess, process, timesteps, x)
 
@@ -52,6 +53,8 @@ end
 
 endpoint_conditioned_sample(rng::AbstractRNG, process, s::Real, t::Real, x_0, x_t) =
     endpoint_conditioned_sample.(rng, process, s, t, x_0, x_t)
+
+endpoint_conditioned_sample(P::Process, s::Real, t::Real, x_0, x_t) = endpoint_conditioned_sample(Random.default_rng(), P, s, t, x_0, x_t)
 
 function checktimesteps(timesteps)
     length(timesteps) ≥ 2 || throw(ArgumentError("timesteps must have at least two timesteps"))

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,8 @@
 #Type system
 abstract type Process end
 
+Base.broadcastable(x::Process) = Ref(x)
+
 abstract type DiffusionProcess <: Process end #Can propogate uncertainty with forward! and backward!
 abstract type SimulationProcess <: Process end #Only deals with point masses. We might switch to everything using point masses, so we might not need this layer
 


### PR DESCRIPTION
This attempts angular diffusion using wrapped Brownian motion, where the endpoint conditioned (bridge) sampling is exact, sampling from a mixture of Gaussians, rather than using the the shortest angle correction trick.

It also embraces the new interface, and avoids creating any internal states - there is no state representation at all. The code is much shorter as a result.