### PR TITLE
change constructor of OrnsteinUhlenbeckDiffusion

### DIFF
--- a/examples/montecatto.jl
+++ b/examples/montecatto.jl
@@ -30,8 +30,8 @@ function monte_carlo_expect(g2,T; P = P, sample_func = target_sample, n_samples 
     return g0.μ
 end
 
-#Define a zero-mean OU process, with default volitility and reversion parameters
-P = OrnsteinUhlenbeckDiffusion(0.0)
+#Define a zero-mean OU process, with reversion 0.5 and default volitility
+P = OrnsteinUhlenbeckDiffusion(0.5)
 
 #We'll work with 2-by-500 gaussians, where each pair is one point that will become cat-distributed
 x_T = rand(eq_dist(P),(2,400))

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -7,7 +7,22 @@ end
 
 OrnsteinUhlenbeckDiffusion(mean::Real, volatility::Real, reversion::Real) = OrnsteinUhlenbeckDiffusion(float.(promote(mean, volatility, reversion))...)
 
-OrnsteinUhlenbeckDiffusion(mean::T) where T <: Real = OrnsteinUhlenbeckDiffusion(mean,T(1.0),T(0.5))
+"""
+    OrnsteinUhlenbeckDiffusion(θ; σ = √(2θ), μ = 0)
+
+Create an Ornstein-Uhlenbeck diffusion.
+
+The process is defined by the following stochastic differential equation:
+
+    dx_t = -θ (μ - x_t) dt + σ dW_t,
+
+where W_t denotes the Wiener process.
+
+The process converges to a normal distribtuion with mean `μ` and variance `σ^2 /
+2θ` at equilibrium.  The default volatility `σ` and mean `μ` are defined so that
+the process converges to the standard normal distribution.
+"""
+OrnsteinUhlenbeckDiffusion(θ::Real; σ::Real = √(2θ), μ::Real = 0) = OrnsteinUhlenbeckDiffusion(μ, σ, θ)
 
 var(model::OrnsteinUhlenbeckDiffusion) = (model.volatility^2) / (2 * model.reversion)
 

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -12,9 +12,9 @@ OrnsteinUhlenbeckDiffusion(mean::Real, volatility::Real, reversion::Real) = Orns
 
 Create an Ornstein-Uhlenbeck diffusion.
 
-The process is defined by the following stochastic differential equation:
+The process (X_t) is defined by the following stochastic differential equation:
 
-    dx_t = -θ (μ - x_t) dt + σ dW_t,
+    dX_t = -θ (μ - X_t) dt + σ dW_t,
 
 where W_t denotes the Wiener process.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Random
 using Test
 
 @testset "Diffusion" begin
-    diffusion = OrnsteinUhlenbeckDiffusion(0.0)
+    diffusion = OrnsteinUhlenbeckDiffusion(1.0)
 
     # 2d diffusion
     x_0 = randn(2)
@@ -24,7 +24,7 @@ using Test
     @test size(x_t) == size(x_0)
 
     diffusion = (
-        OrnsteinUhlenbeckDiffusion(0.0),
+        OrnsteinUhlenbeckDiffusion(1.0),
         UniformDiscreteDiffusion(1.0, 4),
     )
 


### PR DESCRIPTION
I'd like to propose changing the parametrization of the constructor of `OrnsteinUhlenbeckDiffusion`. The rationale behind this is that we typically want to tune the speed of convergence by changing the reversion parameter while keeping the distribution at equilibrium unchanged. Also, I think we won't tune the mean parameter in most cases because it is not very important in diffusion models. I also added a short docstring to the constructor.