### PR TITLE
WIP: masked arrays

### DIFF
--- a/src/Diffusions.jl
+++ b/src/Diffusions.jl
@@ -18,6 +18,7 @@ module Diffusions
     include("tracker.jl")
     include("utils.jl")
     include("randomfourierfeatures.jl")
+    include("maskedarrays.jl")
     include("interface.jl")
 
     export

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -80,6 +80,6 @@ endpoint_conditioned_sample(P::Process, s::Real, t::Real, x_0, x_t) = endpoint_c
 
 function checktimesteps(timesteps)
     length(timesteps) ≥ 2 || throw(ArgumentError("timesteps must have at least two timesteps"))
-    issorted(timesteps) || throw(ArgumentError("timesteps must be decreasing"))
+    issorted(timesteps) || throw(ArgumentError("timesteps must be increasing"))
     all(>(0), timesteps) || throw(ArgumentError("all timesteps must be positive"))
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -20,11 +20,10 @@ function sampleforward(rng::AbstractRNG, process::TractableProcess, t::Real, x::
 end
 
 function sampleforward(rng::AbstractRNG, process::Process, t::AbstractVector{<: Real}, x)
-    x_t = similar(x)
     d = ndims(x)
+    x_t = similar(x)
     for i in axes(x, d)
-        x_t_i = selectdim(x_t, d, i)
-        x_t_i .= sampleforward(rng, process, t[i], selectdim(x, d, i))
+        selectdim(x_t, d, i) .= sampleforward(rng, process, t[i], selectdim(x, d, i))
     end
     return x_t
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -15,7 +15,7 @@ sampleforward(rng::AbstractRNG, process::TractableProcess, t::Real, x) = sample(
 
 function sampleforward(rng::AbstractRNG, process::TractableProcess, t::Real, x::MaskedArray)
     x = copy(x)
-    updatemasked!(x, sampleforward(rng, process, t, maskedvec(x)))
+    maskedvec(x) .= sampleforward(rng, process, t, maskedvec(x))
     return x
 end
 
@@ -69,7 +69,7 @@ function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real
     prior = forward(process, maskedvec(x_0), 0, s)
     likelihood = backward(process, maskedvec(x_t), s, t)
     x = copy(x_t)
-    updatemasked!(x, sample(rng, combine(prior, likelihood)))
+    maskedvec(x) .= sample(rng, combine(prior, likelihood))
     return x
 end
 

--- a/src/maskedarrays.jl
+++ b/src/maskedarrays.jl
@@ -23,6 +23,7 @@ end
 Return the number of masked elements.
 """
 nmasked(A::MaskedArray) = length(A.indices)
+nmasked(A::AbstractArray) = length(A)
 
 """
     maskedvec(A)
@@ -30,6 +31,7 @@ nmasked(A::MaskedArray) = length(A.indices)
 Return a view of masked elements as a vector.
 """
 maskedvec(A::MaskedArray) = view(A.data, A.indices)
+maskedvec(A::AbstractArray) = view(A, :)
 
 """
     mask(data, mask)

--- a/src/maskedarrays.jl
+++ b/src/maskedarrays.jl
@@ -1,0 +1,37 @@
+struct MaskedArray{T, A <: AbstractArray, N} <: AbstractArray{T, N}
+    data::A
+    mask::BitArray{N}
+
+    function MaskedArray(data::AbstractArray{T, N}, mask::BitArray{N}) where {T, N}
+        size(data) == size(mask) || throw(ArgumentError("data and mask must have the same size"))
+        return new{T, typeof(data), N}(data, mask)
+    end
+end
+
+Base.size(A::MaskedArray) = size(A.data)
+Base.copy(A::MaskedArray) = MaskedArray(copy(A.data), copy(A.mask))
+Base.getindex(A::MaskedArray, i...) = A.data[i...]
+
+function Base.setindex!(A::MaskedArray, val, i...)
+    A.data[i...] = val
+    return A
+end
+
+maskedvec(A::MaskedArray) = A.data[A.mask]
+
+function updatemasked!(A::MaskedArray, vals::AbstractVector)
+    A.data[A.mask] .= vals
+    return A
+end
+
+"""
+    mask(data, mask)
+
+Create a masked array.
+
+`data` and `mask` must have the same size.
+"""
+mask(data::AbstractArray, mask::AbstractArray{Bool}) = MaskedArray(data, convert(BitArray, mask)) 
+
+# avoid nesting masked arrays
+mask(masked::MaskedArray, mask::AbstractArray{Bool}) = MaskedArray(masked.data, mask)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Diffusions
-using Diffusions: MaskedArray, mask, maskedvec, updatemasked!
+using Diffusions: MaskedArray, mask, nmasked, maskedvec
 using Random
 using OneHotArrays
 using StaticArrays
@@ -169,9 +169,7 @@ end
     function guess(x, t)
         # random "guess" for testing
         x = copy(x)
-        v = maskedvec(x)
-        v .+= randn(size(v))
-        updatemasked!(x, v)
+        maskedvec(x) .+= randn(nmasked(x))
         return x
     end
     x = samplebackward(guess, process, [1/8, 1/4, 1/2, 1/1], x_t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Diffusions
+using Diffusions: mask, MaskedArray
 using Random
 using OneHotArrays
 using StaticArrays
@@ -152,4 +153,21 @@ end
     @test rff isa RandomFourierFeatures{Float32}
     @test rff(1.0) isa Vector{Float32}
     @test rff([1.0]) isa Matrix{Float32}
+end
+
+@testset "Masked Diffusion" begin
+    process = OrnsteinUhlenbeckDiffusion(0.0, 1.0, 0.5)
+    x_0 = randn(5, 10)
+    m = x_0 .< 0
+    masked = mask(x_0, m)
+    x_t = sampleforward(process, 1.0, masked)
+    @test size(x_t) == size(x_0)
+    @test x_t isa MaskedArray
+    for i in eachindex(x_0)
+        if m[i]
+            @test x_0[i] != x_t[i]
+        else
+            @test x_0[i] == x_t[i]
+        end
+    end
 end


### PR DESCRIPTION
This PR introduces `MaskedArray` type, which is a pair of an array (`data`) and a mask array (`mask`). `sampleforward`, `samplebackward`, and other diffusion functions will operate only on masked elements.

This addresses #41.