### PR TITLE
Make IndependentDiscreteDiffusion's states as static vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+/*.jl

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
 Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Distributions = "0.25"

--- a/src/Diffusions.jl
+++ b/src/Diffusions.jl
@@ -6,6 +6,7 @@ module Diffusions
     using Rotations
     using Quaternions
     using InverseFunctions: inverse, square
+    using StaticArrays: SVector
 
     include("types.jl")
     include("randomvariable.jl")

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -6,6 +6,7 @@ struct IndependentDiscreteDiffusion{K, T <: Real} <: DiscreteStateProcess
 
     function IndependentDiscreteDiffusion{T}(r::T, π::SVector{K, T}) where {K, T <: Real}
         r > 0 || throw(ArgumentError("r must be positive"))
+        sum(π) > 0 || throw(ArgumentError("sum of π must be positive"))
         all(≥(0), π) || throw(ArgumentError("elements of π must be non-negative"))
         return new{K, T}(r, π ./ sum(π))
     end

--- a/src/randomvariable.jl
+++ b/src/randomvariable.jl
@@ -18,16 +18,16 @@ function combine(X::GaussianVariables, lik)
 end
 
 
-struct CategoricalVariables{T, A <: AbstractArray{T}}
-    # the first dimension stores a vector of probabilities
-    p::A
+struct CategoricalVariables{K, T}
+    p::Array{SVector{K, T}}
 end
 
-ncategories(X::CategoricalVariables) = size(X.p, 1)
+ncategories(::CategoricalVariables{K}) where K = K
 
-Base.size(X::CategoricalVariables) = Base.tail(size(X.p))
+Base.size(X::CategoricalVariables) = size(X.p)
 
-sample(rng::AbstractRNG, X::CategoricalVariables) = onehotbatch(randcat(rng, X.p),1:size(X.p,1))
+sample(rng::AbstractRNG, X::CategoricalVariables) =
+    onehotbatch([randcat(rng, p) for p in X.p], 1:ncategories(X))
 
 function combine(X::CategoricalVariables, lik)
     p = copy(X.p) .* lik
@@ -36,4 +36,3 @@ function combine(X::CategoricalVariables, lik)
     end
     return CategoricalVariables(p)
 end
-

--- a/src/randomvariable.jl
+++ b/src/randomvariable.jl
@@ -26,13 +26,21 @@ ncategories(::CategoricalVariables{K}) where K = K
 
 Base.size(X::CategoricalVariables) = size(X.p)
 
-sample(rng::AbstractRNG, X::CategoricalVariables) =
-    onehotbatch([randcat(rng, p) for p in X.p], 1:ncategories(X))
+function sample(rng::AbstractRNG, X::CategoricalVariables{K, T}) where {K, T}
+    x = Array{SVector{K, Int}}(undef, size(X))
+    for i in eachindex(x, X.p)
+        k = randcat(rng, X.p[i])
+        x[i] = onehotsvec(K, k)
+    end
+    return x
+end
+
+onehotsvec(K, k) = SVector{K}(ntuple(_ -> 0, k - 1)..., 1, ntuple(_ -> 0, K - k)...) 
 
 function combine(X::CategoricalVariables, lik)
-    p = copy(X.p) .* lik
-    for i in CartesianIndices(size(X))
-        p[:,i] ./= sum(@view p[:,i])
+    p = map(.*, X.p, lik)
+    for i in eachindex(p)
+        p[i] = p[i] ./ sum(p[i])
     end
     return CategoricalVariables(p)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,26 +1,3 @@
-#=
-# Random sampling from categorical distributions
-randcat(p::AbstractArray) = randcat(Random.default_rng(), p)
-
-function randcat(rng::AbstractRNG, p::AbstractArray)
-    K = size(p, 1)
-    @assert K ≥ 1
-    X = zeros(Int, Base.tail(size(p)))
-    for ix in CartesianIndices(size(X))
-        # This algorithm is O(K), but it is fine because we don't generate many
-        # samples from the same distribution.
-        u = rand(rng, eltype(p))
-        k = 0
-        while u ≥ 0 && k < K
-            k += 1
-            u -= p[k,ix]
-        end
-        X[ix] = k
-    end
-    return X
-end
-=#
-
 function randcat(rng::AbstractRNG, p::AbstractVector)
     K = length(p)
     @assert K ≥ 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,4 @@
+#=
 # Random sampling from categorical distributions
 randcat(p::AbstractArray) = randcat(Random.default_rng(), p)
 
@@ -17,6 +18,21 @@ function randcat(rng::AbstractRNG, p::AbstractArray)
         X[ix] = k
     end
     return X
+end
+=#
+
+function randcat(rng::AbstractRNG, p::AbstractVector)
+    K = length(p)
+    @assert K ≥ 1
+    # This algorithm is O(K), but it is fine because we don't generate many
+    # samples from the same distribution.
+    u = rand(rng, eltype(p))
+    k = 0
+    while u ≥ 0 && k < K
+        k += 1
+        u -= p[k]
+    end
+    return k
 end
 
 """

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "c05f26797ebfd235aeaafd9a485cafa9a6d950a8"
+project_hash = "380947eea551eea24a4b624ca8e187a027ae1d83"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
@@ -158,6 +158,17 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "b8d897fe7fa688e93aef573711cb207c08c9e11e"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.5.19"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,9 +76,9 @@ end
         diffusion = IndependentDiscreteDiffusion(r, ones(SVector{k, Float64}))
         x_0 = fill([1; zero(SVector{k-1, Int})], n_samples)
         x_t = sampleforward(diffusion, t, x_0)
-        p1 = sum(onecold(x_t) .== 1) / n_samples
+        p1 = sum(onecold.(x_t) .== 1) / n_samples
         @test isapprox(p1, P_t[1,1]; rtol)
-        p2 = sum(onecold(x_t) .== 2) / n_samples
+        p2 = sum(onecold.(x_t) .== 2) / n_samples
         @test isapprox(p2, P_t[1,2]; rtol)
 
         # non-uniform distribution at equilibrium
@@ -88,9 +88,9 @@ end
         diffusion = IndependentDiscreteDiffusion(r, π)
         x_0 = fill([1; zero(SVector{k-1, Int})], n_samples)
         x_t = sampleforward(diffusion, t, x_0)
-        p1 = sum(onecold(x_t) .== 1) / n_samples
+        p1 = sum(onecold.(x_t) .== 1) / n_samples
         @test isapprox(p1, P_t[1,1]; rtol)
-        p2 = sum(onecold(x_t) .== 2) / n_samples
+        p2 = sum(onecold.(x_t) .== 2) / n_samples
         @test isapprox(p2, P_t[1,2]; rtol)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,22 @@ using OneHotArrays
 using StaticArrays
 using Test
 
+@testset "Random categorical" begin
+    rng = Xoshiro(12345)
+    p = [0.1, 0.2, 0.3, 0.4]
+    x = randcat(rng, p)
+    @test x isa Int
+
+    N = 1_000_000
+    x = [randcat(rng, p) for _ in 1:N]
+    @test minimum(x) ≥ 1
+    @test maximum(x) ≤ 4
+    @test 0.099 < sum(==(1), x) / N < 0.101
+    @test 0.199 < sum(==(2), x) / N < 0.201
+    @test 0.299 < sum(==(3), x) / N < 0.301
+    @test 0.399 < sum(==(4), x) / N < 0.401
+end
+
 @testset "Diffusion" begin
     diffusion = OrnsteinUhlenbeckDiffusion(0.0)
 
@@ -137,26 +153,3 @@ end
     @test rff(1.0) isa Vector{Float32}
     @test rff([1.0]) isa Matrix{Float32}
 end
-
-#=
-@testset "Random categorical" begin
-    rng = Xoshiro(12345)
-    p = [
-        0.1 0.3
-        0.2 0.5
-        0.7 0.2
-    ]
-    x = randcat(rng, p)
-    @test size(x) == (2,)
-    @test x isa Vector{Int}
-
-    # test a point to avoid stupid bugs
-    N = 1_000_000
-    n = 0
-    for _ in 1:N
-        x = randcat(rng, p)
-        n += x[1] == 1
-    end
-    @test 0.099 < n / N < 0.101
-end
-=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Diffusions
 using Random
 using OneHotArrays
+using StaticArrays
 using Test
 
 @testset "Diffusion" begin
@@ -46,18 +47,18 @@ end
 
 @testset "Discrete Diffusions" begin
     for T in [Float32, Float64]
-        diffusion = IndependentDiscreteDiffusion(T(1.0), ones(T, 10))
-        @test diffusion isa IndependentDiscreteDiffusion{T}
+        diffusion = IndependentDiscreteDiffusion(one(T), ones(SVector{10, T}))
+        @test diffusion isa IndependentDiscreteDiffusion{10, T}
         @test diffusion.r ≈ T(1.0)
         @test diffusion.π ≈ ones(T, 10) ./ 10  # check normalization
     end
 
-    diffusion = IndependentDiscreteDiffusion(1.0f0, ones(10))
-    @test diffusion isa IndependentDiscreteDiffusion{Float64}
+    diffusion = IndependentDiscreteDiffusion(1.0f0, ones(SVector{10, Float64}))
+    @test diffusion isa IndependentDiscreteDiffusion{10, Float64}
 
     n_samples = 10_000_000
     rtol = 0.01
-    ratematrix(π) = [i == j ? -(sum(π) - π[j]) : π[j] for i in eachindex(π), j in eachindex(π)]
+    ratematrix(π) = [i == j ? π[j] - 1 : π[j] for i in eachindex(π), j in eachindex(π)]
     for r in [0.5, 1.0, 2.0], t in [0.1, 1.0, 10.0]
         # uniform distribution at equilibrium
         k = 5
@@ -72,8 +73,8 @@ end
         p2 = sum(x_t .== 2) / n_samples
         @test isapprox(p2, P_t[1,2]; rtol)
 
-        diffusion = IndependentDiscreteDiffusion(r, ones(k) ./ k)
-        x_0 = onehotbatch(fill(1, n_samples), 1:k)
+        diffusion = IndependentDiscreteDiffusion(r, ones(SVector{k, Float64}))
+        x_0 = fill([1; zero(SVector{k-1, Int})], n_samples)
         x_t = sampleforward(diffusion, t, x_0)
         p1 = sum(onecold(x_t) .== 1) / n_samples
         @test isapprox(p1, P_t[1,1]; rtol)
@@ -81,11 +82,11 @@ end
         @test isapprox(p2, P_t[1,2]; rtol)
 
         # non-uniform distribution at equilibrium
-        π = [0.05, 0.05, 0.2, 0.3, 0.4]
+        π = @SVector [0.05, 0.05, 0.2, 0.3, 0.4]
         Q = ratematrix(π)
         P_t = exp(Q * r * t)
         diffusion = IndependentDiscreteDiffusion(r, π)
-        x_0 = onehotbatch(fill(1, n_samples), 1:k)
+        x_0 = fill([1; zero(SVector{k-1, Int})], n_samples)
         x_t = sampleforward(diffusion, t, x_0)
         p1 = sum(onecold(x_t) .== 1) / n_samples
         @test isapprox(p1, P_t[1,1]; rtol)
@@ -137,6 +138,7 @@ end
     @test rff([1.0]) isa Matrix{Float32}
 end
 
+#=
 @testset "Random categorical" begin
     rng = Xoshiro(12345)
     p = [
@@ -157,3 +159,4 @@ end
     end
     @test 0.099 < n / N < 0.101
 end
+=#


### PR DESCRIPTION
This is a stepping stone to implement state masking in a simpler way. A drawback of this approach is that IndependentDiscreteDiffusion will perform poorly for a large state space, because static arrays aren't optimized for large arrays. I think this is acceptable because we mainly use this diffusion for a state space with tens or less distinct states.