### PR TITLE
Handle masking more consistently (fix #52)

### DIFF
--- a/examples/rotation_manifold.jl
+++ b/examples/rotation_manifold.jl
@@ -78,7 +78,7 @@ for iter in 1:250000
     #Loss and gradient
     l,gs = Flux.withgradient(ps) do
         x0hat_flatquats = rotmodel(xt_flatquats,t)
-        standardloss(P, t, x0hat_flatquats, x0_flatquats)
+        standardloss(P, t, x0hat_flatquats, x0)
     end
     
     #Update the parameters

--- a/src/JC.jl
+++ b/src/JC.jl
@@ -33,7 +33,7 @@ end
 #pls check for correctness, and make sure types are preserved
 #This works by pre-calculating the five possible outcomes of the combine(fwd(X0),back(Xt)) of JC69
 #Then only sampling when the random draw suggests the state will differ from Xt.
-function endpoint_conditioned_sample(rng::AbstractRNG, P::UniformDiscreteDiffusion, s::Real, t::Real, X0, Xt)
+function _endpoint_conditioned_sample(rng::AbstractRNG, P::UniformDiscreteDiffusion, s::Real, t::Real, X0, Xt)
     Xs = copy(Xt)
     k = P.k
     Fw = 1-exp(-s*P.rate)

--- a/src/angles.jl
+++ b/src/angles.jl
@@ -55,7 +55,7 @@ function wrapped_combine_and_sample(rng::AbstractRNG, P::WrappedInterpolatedBrow
     return reangle(B + dir * shortestdist * (var / (var + back_var)))
 end
 
-sampleforward(rng::AbstractRNG, P::WrappedDiffusion{T}, t::Real, X::AbstractArray) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
+_sampleforward(rng::AbstractRNG, P::WrappedDiffusion{T}, t::Real, X::AbstractArray) where T = X .+ reangle.(randn(rng, T, size(X)) .* sqrt(t*P.rate))
 
-endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedDiffusion, s::Real, t::Real, x_0, x_t) =
+_endpoint_conditioned_sample(rng::AbstractRNG, P::WrappedDiffusion, s::Real, t::Real, x_0::AbstractArray, x_t::AbstractArray) =
     wrapped_combine_and_sample.(rng, P, x_0, P.rate * s, x_t, P.rate * (t - s))

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -31,3 +31,9 @@ end
 
 _sampleforward(rng::AbstractRNG, process::OrnsteinUhlenbeckDiffusion, t::Real, x::AbstractArray) =
     sample(rng, forward(process, x, 0, t))
+
+function _endpoint_conditioned_sample(rng::AbstractRNG, process::OrnsteinUhlenbeckDiffusion, s::Real, t::Real, x_0::AbstractArray, x_t::AbstractArray)
+    prior = forward(process, x_0, 0, s)
+    likelihood = backward(process, x_t, s, t)
+    return sample(rng, combine(prior, likelihood))
+end

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -48,3 +48,9 @@ end
 
 _sampleforward(rng::AbstractRNG, process::IndependentDiscreteDiffusion, t::Real, x::AbstractArray) =
     sample(rng, forward(process, x, 0, t))
+
+function _endpoint_conditioned_sample(rng::AbstractRNG, process::IndependentDiscreteDiffusion, s::Real, t::Real, x_0::AbstractArray, x_t::AbstractArray)
+    prior = forward(process, x_0, 0, s)
+    likelihood = backward(process, x_t, s, t)
+    return sample(rng, combine(prior, likelihood))
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -69,9 +69,11 @@ function samplebackward(rng::AbstractRNG, guess, process, timesteps, x; tracker=
     return x
 end
 
-function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real, t::Real, x_0::AbstractArray, x_t::MaskedArray)
-    # x_0 inherits masked elements from x_t
-    x_0 = MaskedArray(x_0, x_t.indices)
+function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real, t::Real, x_0::AbstractArray, x_t::AbstractArray)
+    if x_t isa MaskedArray
+        # x_0 inherits masked elements from x_t
+        x_0 = MaskedArray(x_0, x_t.indices)
+    end
     x = copy(x_t)
     maskedvec(x) .= _endpoint_conditioned_sample(rng, process, s, t, maskedvec(x_0), maskedvec(x_t))
     return x

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,3 +1,12 @@
+# sampleforward and samplebackward are the main interface functions.
+# 
+# A diffusion process type must implement two methods of the following functions:
+# 1. _sampleforward(rng, process, t, x_0): draw a sample at time t, conditioned on x_0 at time 0
+# 2. _endpoint_conditioned_sample(rng, process, s, t, x_0, x_t): draw a sample at time s, conditioned on x_0 at time 0 and x_t time t
+#
+# Note that arrays passed to these functions (i.e., x_0 and x_t) are not masked
+# arrays because masking layers are removed before passed to them.
+
 """
     sampleforward(process, t, x)
 
@@ -12,10 +21,10 @@ sampleforward(process, t, x) = sampleforward(Random.default_rng(), process, t, x
 
 sampleforward(
     rng::AbstractRNG,
-    process::NTuple{N, Process},
-    t::Union{Real, AbstractVector{<: Real}},
-    x::NTuple{N, AbstractArray}
-) where N = sampleforward.(rng, process, (t,), x)
+    process::NTuple{N,Process},
+    t::Union{Real,AbstractVector{<:Real}},
+    x::NTuple{N,AbstractArray}
+) where {N} = sampleforward.(rng, process, (t,), x)
 
 function sampleforward(rng::AbstractRNG, process::Process, t::Real, x::AbstractArray)
     x = copy(x)
@@ -23,7 +32,7 @@ function sampleforward(rng::AbstractRNG, process::Process, t::Real, x::AbstractA
     return x
 end
 
-function sampleforward(rng::AbstractRNG, process::Process, t::AbstractVector{<: Real}, x::AbstractArray)
+function sampleforward(rng::AbstractRNG, process::Process, t::AbstractVector{<:Real}, x::AbstractArray)
     x = copy(x)
     for i in axes(x, ndims(x))
         maskedvec(x, i) .= _sampleforward(rng, process, t[i], maskedvec(x, i))
@@ -42,10 +51,10 @@ Draw samples backward (i.e., denoise).
 - `timesteps`: a vector of positive times (e.g., `5.0 * (1 - 0.05).^(100:-1:0)`)
 - `x`: data points at time `timesteps[end]` (e.g., samples from the equilibrium distribution)
 """
-samplebackward(guess, process, timesteps, x; tracker = NullTracker()) =
+samplebackward(guess, process, timesteps, x; tracker=NullTracker()) =
     samplebackward(Random.default_rng(), guess, process, timesteps, x; tracker)
 
-function samplebackward(rng::AbstractRNG, guess, process, timesteps, x; tracker = NullTracker())
+function samplebackward(rng::AbstractRNG, guess, process, timesteps, x; tracker=NullTracker())
     checktimesteps(timesteps)
     i = lastindex(timesteps)
     t = timesteps[i]
@@ -60,24 +69,18 @@ function samplebackward(rng::AbstractRNG, guess, process, timesteps, x; tracker 
     return x
 end
 
-# sample x at time s conditioned on x_0 at time 0 and x_t at time t
-function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real, t::Real, x_0, x_t)
-    prior = forward(process, x_0, 0, s)
-    likelihood = backward(process, x_t, s, t)
-    return sample(rng, combine(prior, likelihood))
-end
-
-function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real, t::Real, x_0::MaskedArray, x_t::MaskedArray)
-    prior = forward(process, maskedvec(x_0), 0, s)
-    likelihood = backward(process, maskedvec(x_t), s, t)
+function endpoint_conditioned_sample(rng::AbstractRNG, process::Process, s::Real, t::Real, x_0::AbstractArray, x_t::MaskedArray)
+    # x_0 inherits masked elements from x_t
+    x_0 = MaskedArray(x_0, x_t.indices)
     x = copy(x_t)
-    maskedvec(x) .= sample(rng, combine(prior, likelihood))
+    maskedvec(x) .= _endpoint_conditioned_sample(rng, process, s, t, maskedvec(x_0), maskedvec(x_t))
     return x
 end
 
 endpoint_conditioned_sample(rng::AbstractRNG, process, s::Real, t::Real, x_0, x_t) =
     endpoint_conditioned_sample.(rng, process, s, t, x_0, x_t)
 
+# sample x at time s conditioned on x_0 at time 0 and x_t at time t
 endpoint_conditioned_sample(P::Process, s::Real, t::Real, x_0, x_t) = endpoint_conditioned_sample(Random.default_rng(), P, s, t, x_0, x_t)
 
 function checktimesteps(timesteps)

--- a/src/maskedarrays.jl
+++ b/src/maskedarrays.jl
@@ -8,6 +8,10 @@ struct MaskedArray{T, N, A <: AbstractArray, I <: AbstractVector{<: Integer}} <:
     end
 end
 
+# avoid nested masking
+MaskedArray(data::MaskedArray, indices::AbstractVector{<: Integer}) =
+    MaskedArray(parent(data), indices)
+
 Base.size(A::MaskedArray) = size(A.data)
 Base.copy(A::MaskedArray) = MaskedArray(copy(A.data), copy(A.indices))
 Base.getindex(A::MaskedArray, i...) = A.data[i...]

--- a/src/rotational.jl
+++ b/src/rotational.jl
@@ -41,7 +41,7 @@ RotationDiffusion() = RotationDiffusion(1.0)
 _sampleforward(rng::AbstractRNG, process::RotationDiffusion, t::Real, x::AbstractArray) =
     rotation_diffuse.(rng, x, t * process.rate)
 
-endpoint_conditioned_sample(rng::AbstractRNG, process::RotationDiffusion, s::Real, t::Real, x_0, x_t) =
+_endpoint_conditioned_sample(rng::AbstractRNG, process::RotationDiffusion, s::Real, t::Real, x_0, x_t) =
     rotation_bridge.(rng, x_0, x_t, (t - s) * process.rate, t * process.rate)
 
 function rots2flatquats(r::AbstractArray{QuatRotation{T}}) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,14 @@ end
     @test rff([1.0]) isa Matrix{Float32}
 end
 
+@testset "Backward Diffusion" begin
+    process = OrnsteinUhlenbeckDiffusion(0.0)
+    x_t = randn(4, 10)
+    x = samplebackward((x, t) -> x + randn(size(x)), process, [1/8, 1/4, 1/2, 1/1], x_t)
+    @test size(x) == size(x_t)
+    @test x isa Matrix
+end
+
 @testset "Masked Diffusion" begin
     process = OrnsteinUhlenbeckDiffusion(0.0, 1.0, 0.5)
     x_0 = randn(5, 10)


### PR DESCRIPTION
This will fix #52 by introducing `_endpoint_conditioned_sample` to all diffusion types and forcing mask inheritance from x_t. I also added some tests and code cleanups. This will supersede #53.